### PR TITLE
Remove deprecated usages of `set-ouput` per warnings

### DIFF
--- a/dokku/create-review-app/action.yaml
+++ b/dokku/create-review-app/action.yaml
@@ -28,10 +28,10 @@ runs:
 
           if [ -z "$exit_code" ]; then
               echo "App already exists. Skipping creation..."
-              echo ::set-output name=app_exists::"true"
+              echo "app_exists='true'" >> $GITHUB_OUTPUT
           elif [ "$exit_code" -eq 20 ]; then
             echo "App does not exists. Creating review app..."
-            echo ::set-output name=app_exists::"false"
+            echo "app_exists='false'" >> $GITHUB_OUTPUT
           else
             echo "The checking command failed...exiting."
             exit 1

--- a/square1/build-node/action.yml
+++ b/square1/build-node/action.yml
@@ -17,13 +17,13 @@ runs:
     - name: Get yarn cache directory path
       shell: bash
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUPUT
 
     - name: Get yarn hash key
       shell: bash
       id: yarn-hashfile
       working-directory: ${{ inputs.folder }}
-      run: echo "::set-output name=hash::${{ hashFiles('**/yarn.lock') }}"
+      run: echo "hash=${{ hashFiles('**/yarn.lock') }}" >> $GITHUB_OUPUT
 
     - uses: actions/cache@v4
       id: yarn-cache

--- a/square1/composer/action.yml
+++ b/square1/composer/action.yml
@@ -33,7 +33,7 @@ runs:
       working-directory: ${{ inputs.folder }}
       shell: bash
       run: |
-        echo "::set-output name=dir::$(composer config cache-files-dir)"
+        echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v4
       if: ${{ inputs.disable_cache == 'true' }}

--- a/utils/common-variables/action.yml
+++ b/utils/common-variables/action.yml
@@ -30,17 +30,17 @@ runs:
         BASE_BRANCH: ${{ inputs.base_branch }}
       run: |
         echo "BRANCH=$(echo ${BASE_BRANCH#refs/heads/})" >> $GITHUB_ENV
-        echo "##[set-output name=branch;]$(echo ${BASE_BRANCH#refs/heads/})"
+        echo "branch=$(echo ${BASE_BRANCH#refs/heads/})" >> $GITHUB_OUPUT
       shell: bash
 
     - id: github-runner-url
       run: |
         echo "GHA_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
-        echo "::set-output name=gha-url::$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        echo "gha-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUPUT
       shell: bash
 
     - id: set-review-app
       run: |
         echo "REVIEW_APP=${{ inputs.app_name }}-pr${{ inputs.pr_number }}" >> $GITHUB_ENV
-        echo "::set-output name=review-app::${{ inputs.app_name }}-pr${{ inputs.pr_number }}"
+        echo "review-app=${{ inputs.app_name }}-pr${{ inputs.pr_number }}" >> $GITHUB_OUPUT
       shell: bash


### PR DESCRIPTION
Removes usages of `set-output` per GHA deprecation warnings.

Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/